### PR TITLE
Update plotsvy to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "broadcast-channel": "^2.1.10",
     "css-loader": "^2.1.1",
     "physiomeportal": "^0.4.4",
-    "plotsvy": "^0.3.0",
+    "plotsvy": "^0.3.2",
     "webpack-bundle-analyzer": "^3.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "broadcast-channel": "^2.1.10",
     "css-loader": "^2.1.1",
     "physiomeportal": "^0.4.4",
-    "plotsvy": "^0.3.2",
+    "plotsvy": "^0.3.4",
     "webpack-bundle-analyzer": "^3.4.1"
   }
 }


### PR DESCRIPTION
There was a major UI fix to dat.gui css where the div clips and dat.gui
is not shown.

I also came up with a solution for the dat.gui div taking input from the graph, which is giving it a small div but allowing it to expand past 100% height. 